### PR TITLE
feat(feed): add auto download ui when adding rss feed

### DIFF
--- a/Business/Sources/Business/Podcast/DataSources/RemotePodcastDataSourceContract.swift
+++ b/Business/Sources/Business/Podcast/DataSources/RemotePodcastDataSourceContract.swift
@@ -3,5 +3,5 @@ import Foundation
 
 public protocol RemotePodcastDataSourceContract: Sendable {
     func podcasts(baseURL: String, token: String) async throws(CoreError) -> [Podcast]
-    func registerFeed(from rssURL: URL, baseURL: String, token: String) async throws(CoreError) -> Podcast
+    func registerFeed(from rssURL: URL, downloadMode: DownloadMode, baseURL: String, token: String) async throws(CoreError) -> Podcast
 }

--- a/Business/Sources/Business/Podcast/Repositories/PodcastRepository.swift
+++ b/Business/Sources/Business/Podcast/Repositories/PodcastRepository.swift
@@ -108,12 +108,12 @@ extension PodcastRepository {
 
 // MARK: RSS Feed
 extension PodcastRepository {
-    public func addPodcast(fromRSS rssURL: URL) async throws(CoreError) {
+    public func addPodcast(fromRSS rssURL: URL, downloadMode: DownloadMode) async throws(CoreError) {
         guard let token = await serverProvider.token?.token,
               let server = await serverProvider.server
         else { throw CoreError.notAuthenticated(layer: .business, feature: .podcasts) }
         
-        let podcast = try await remote.registerFeed(from: rssURL, baseURL: server, token: token)
+        let podcast = try await remote.registerFeed(from: rssURL, downloadMode: downloadMode, baseURL: server, token: token)
         try await local.upsert([podcast])
     }
 }

--- a/Core/Sources/Core/Podcasts/Repositories/PodcastRepositoryContract.swift
+++ b/Core/Sources/Core/Podcasts/Repositories/PodcastRepositoryContract.swift
@@ -7,5 +7,5 @@ public protocol PodcastRepositoryContract: Sendable {
     func refreshPodcast(with id: UUID, force: Bool) async throws(CoreError)
     func refreshPodcasts(force: Bool) async throws(CoreError)
     
-    func addPodcast(fromRSS rssURL: URL) async throws(CoreError)
+    func addPodcast(fromRSS rssURL: URL, downloadMode: DownloadMode) async throws(CoreError)
 }

--- a/Core/Sources/Core/RSS/DownloadMode.swift
+++ b/Core/Sources/Core/RSS/DownloadMode.swift
@@ -1,0 +1,5 @@
+public enum DownloadMode: Sendable {
+    case none
+    case new
+    case newAndExisting
+}

--- a/Data/Sources/Data/Auth/DataSources/CobwebRemoteAuthDataSource.swift
+++ b/Data/Sources/Data/Auth/DataSources/CobwebRemoteAuthDataSource.swift
@@ -15,7 +15,7 @@ public struct CobwebRemoteAuthDataSource: RemoteAuthDataSourceContract {
     public func login(baseURL: String, username: String, password: String) async throws(CoreError) -> AuthSession {
         try await CoreError.catchNetwork(performing: "logging in user", logger: logger, feature: .auth) {
             let user = try await Cobweb.URL.using(baseURL: baseURL)
-                .path("/api/auth/login").get()
+                .path("/api/auth/login").post()
                 .also { logger.info("Sending Request to GET /api/auth/login") }
                 .withHeaders(.basicAuth(username: username, password: password))
                 .response()

--- a/Data/Sources/Data/Podcast/DataSources/CobwebRemotePodcastDataSource.swift
+++ b/Data/Sources/Data/Podcast/DataSources/CobwebRemotePodcastDataSource.swift
@@ -25,17 +25,28 @@ public struct CobwebRemotePodcastDataSource: RemotePodcastDataSourceContract {
         }
     }
     
-    public func registerFeed(from rssURL: URL, baseURL: String, token: String) async throws(CoreError) -> Podcast {
+    public func registerFeed(from rssURL: URL, downloadMode: DownloadMode, baseURL: String, token: String) async throws(CoreError) -> Podcast {
         try await CoreError.catchNetwork(performing: "Registering RSS feed", logger: logger, feature: .podcasts) {
             try await Cobweb.URL.using(baseURL: baseURL)
                 .path("/api/podcasts/feeds")
                 .post()
                 .withHeaders(.bearer(token), .contentType(value: "application/json"))
-                .withBody(["url": rssURL])
+                .withBody([
+                    "url": rssURL.absoluteString,
+                    "autoDownload": downloadModeString(for: downloadMode)
+                ])
                 .response()
                 .withStatusCoreError(expecting: 201, feature: .podcasts)
                 .body(as: PodcastDTO.self)
                 .toCore()
+        }
+    }
+    
+    private func downloadModeString(for mode: DownloadMode) -> String {
+        switch mode {
+            case .new: "new"
+            case .newAndExisting: "new_and_existing"
+            case .none: "none"
         }
     }
 }

--- a/Feature/Sources/Podcasts/PodcastList/Components/PodcastListSettingsPopup.swift
+++ b/Feature/Sources/Podcasts/PodcastList/Components/PodcastListSettingsPopup.swift
@@ -9,8 +9,9 @@ struct PodcastListSettingsPopup: View {
     @Environment(\.userRole) private var userRole
     
     @State private var rssFeedURL: URL = URL(string: "//")!
+    @State private var downloadMode: DownloadMode = .new
     
-    let onAddFeed: (URL) -> Void
+    let onAddFeed: (URL, DownloadMode) -> Void
     
     var body: some View {
         BruteStyle {
@@ -24,9 +25,21 @@ struct PodcastListSettingsPopup: View {
                                 .textContentType(.URL)
                                 .textInputAutocapitalization(.never)
                             
+                            VStack(alignment: .leading, spacing: context.dimen.paddingSmall) {
+                                Text("Automatically Download:")
+                                BrutePicker(selection: $downloadMode) {
+                                    Text("New")
+                                        .tag(DownloadMode.new)
+                                    Text("New & Existing")
+                                        .tag(DownloadMode.newAndExisting)
+                                    Text("None")
+                                        .tag(DownloadMode.none)
+                                }
+                            }
+                            
                             Button(
                                 action: {
-                                    onAddFeed(rssFeedURL)
+                                    onAddFeed(rssFeedURL, downloadMode)
                                 },
                                 label: {
                                     Text("Add RSS Feed")
@@ -45,7 +58,7 @@ struct PodcastListSettingsPopup: View {
 
 #Preview {
     PodcastListSettingsPopup(
-        onAddFeed: { _ in }
+        onAddFeed: { _, _ in }
     )
     .environment(\.userRole, .admin)
 }

--- a/Feature/Sources/Podcasts/PodcastList/PodcastListVM.swift
+++ b/Feature/Sources/Podcasts/PodcastList/PodcastListVM.swift
@@ -36,10 +36,10 @@ final class PodcastListVM {
         }
     }
     
-    public func addPodcast(fromRSS rssURL: URL) {
+    public func addPodcast(fromRSS rssURL: URL, downloadMode: DownloadMode) {
         Task {
             do {
-                try await repository.addPodcast(fromRSS: rssURL)
+                try await repository.addPodcast(fromRSS: rssURL, downloadMode: downloadMode)
             } catch let error as CoreError {
                 logger.error("Failed adding rss feed", for: error)
                 navigator.showError(error)

--- a/Feature/Sources/Podcasts/PodcastList/PodcastListView.swift
+++ b/Feature/Sources/Podcasts/PodcastList/PodcastListView.swift
@@ -15,7 +15,7 @@ struct PodcastListView: View {
     
     let onTapPodcast: (Podcast) -> Void
     let onRefresh: @Sendable () async -> Void
-    let onAddFeed: (URL) -> Void
+    let onAddFeed: (URL, DownloadMode) -> Void
     
     var body: some View {
         BruteStyle {
@@ -42,8 +42,8 @@ struct PodcastListView: View {
             }
             .sheet(isPresented: $showSettings) {
                 PodcastListSettingsPopup(
-                    onAddFeed: { url in
-                        onAddFeed(url)
+                    onAddFeed: { url, downloadMode in
+                        onAddFeed(url, downloadMode)
                         showSettings = false
                     }
                 )
@@ -104,7 +104,7 @@ struct PodcastListView: View {
         isLoading: false,
         onTapPodcast: { _ in },
         onRefresh: { },
-        onAddFeed: { _ in }
+        onAddFeed: { _, _ in }
     )
     .environment(\.userRole, .admin)
 }


### PR DESCRIPTION
<!--
PR title must follow commit subject rules, e.g. feat(profile): add avatar upload
It becomes the squashed commit on main. See CONTRIBUTING.md.

Fill in every section below. "See issue" or "small fix" gets this PR closed.
-->

## What
<!-- One or two sentences stating the change. -->
Adds a picker to the add rss feed admin settings on the profile page, for selecting how automatic downloads should work for a given feed.

## Why
<!-- The problem this solves. Link the issue. -->

## How
<!-- The approach you took and any alternatives you rejected. -->

## Checklist

Check every box. Reviewers verify these and close PRs that fail them.

- [x] The branch is rebased on the latest `dev`.
- [x] Every commit follows Conventional Commits (one logical change each, no `wip` commits).
- [x] The diff contains no commented-out code, no debug prints, no unrelated formatting changes.
- [x] This PR resolves exactly one issue.
